### PR TITLE
Disable explicit sync for nvidia to make typhoon work on Wayland.

### DIFF
--- a/io.github.archisman_panigrahi.typhoon.json
+++ b/io.github.archisman_panigrahi.typhoon.json
@@ -10,7 +10,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--device=dri"
+        "--device=dri",
+        "--env=__NV_DISABLE_EXPLICIT_SYNC=1"
     ],
     "modules" : [
         {


### PR DESCRIPTION
Fix for #33

GTK3 does not support Explicit sync (afaik) which was introduced not so long ago. To make Typhoon work on nvidia proprietary drivers and Wayland is to disable explicit sync here. This will not affect any other GPU or driver as this is a nvidia environment variable only the proprietary driver understands. 