### PR TITLE
fix: sanitize shell/subprocess call in typhoon_window.py

### DIFF
--- a/typhoon/typhoon_window.py
+++ b/typhoon/typhoon_window.py
@@ -1132,7 +1132,7 @@ class TyphoonWindow(QWidget):
                 raise RuntimeError("Could not detect primary monitor for XFCE")
             key = f"/backdrop/screen0/monitor{primary_monitor}/workspace0/last-image"
             wallpaper = subprocess.check_output(
-                f'xfconf-query -c xfce4-desktop -p "{key}"', shell=True, text=True
+                ["xfconf-query", "-c", "xfce4-desktop", "-p", key], text=True
             ).strip()
         elif "kde" in de:
             config_file = os.path.expanduser(


### PR DESCRIPTION
## Summary
Fix high severity security issue in `typhoon/typhoon_window.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `typhoon/typhoon_window.py:1105` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: Multiple subprocess.check_output() calls use shell=True with command strings. The XFCE case interpolates a variable derived from xrandr output into the shell command string, creating a potential command injection vector if monitor names can be manipulated with shell metacharacters.

## Evidence

**Exploitation scenario**: An attacker with local system access could configure a display with a monitor name containing shell metacharacters (e.g., `$(cmd)` or `; cmd`), potentially injecting commands via the XFCE wallpaper.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `typhoon/typhoon_window.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
